### PR TITLE
Added support for popular JSON formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,12 +127,11 @@ The generated json file will have one of the following formats:
 	"spriteSourceSize": {"x":0,"y":0,"w":213,"h":159},
 	"sourceSize": {"w":231,"h":175}
 }],
-
 "meta": {
 	"app": "https://github.com/urraka/texpack",
 	"image": "atlas.png",
 	"size": {"w":650,"h":497},
-}
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ Options:
                         * long-side
                         * best-area
                         * contact-point
-
+-f, --format          Specifies the output format of the JSON file. Values are:
+                        * legacy (default; uses the original JSON format created by urraka)
+                        * jsonhash (Texture Atlas JSON Hash format)
+                        * jsonarray (Texture Atlas JSON Array format)
+                        
 (*) The format of the metadata file should be as follows:
 
     {
@@ -50,8 +54,9 @@ Options:
 
 At least one image (the texture atlas) and its corresponding json file will be generated. If the sprites don't fit in the atlas (when using --size or --max-size), a set of images with its json file will be generated.
 
-The generated json file will have a format like this:
+The generated json file will have one of the following formats:
 
+*Legacy*
 ```javascript
 {
     "width": 512,                // texture atlas width
@@ -79,6 +84,55 @@ The generated json file will have a format like this:
         },
         //...
     }
+}
+```
+
+*JSON Hash*
+```javascript
+{"frames": {
+
+"image1":
+{
+	"frame": {"x":249,"y":205,"w":213,"h":159},
+	"rotated": false,
+	"trimmed": true,
+	"spriteSourceSize": {"x":0,"y":0,"w":213,"h":159},
+	"sourceSize": {"w":231,"h":175}
+},
+"image2":
+{
+	"frame": {"x":20,"y":472,"w":22,"h":21},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":22,"h":21},
+	"sourceSize": {"w":22,"h":21}
+}},
+"meta": {
+	"app": "https://github.com/urraka/texpack",
+	"image": "atlas.png",
+	"size": {"w":650,"h":497},
+    }
+}
+```
+
+*JSON Array*
+```javascript
+{"frames": [
+
+{
+	"filename": "image1",
+	"frame": {"x":249,"y":205,"w":213,"h":159},
+	"rotated": false,
+	"trimmed": true,
+	"spriteSourceSize": {"x":0,"y":0,"w":213,"h":159},
+	"sourceSize": {"w":231,"h":175}
+}],
+
+"meta": {
+	"app": "https://github.com/urraka/texpack",
+	"image": "atlas.png",
+	"size": {"w":650,"h":497},
+}
 }
 ```
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,6 +30,7 @@ int main(int argc, char *argv[])
 		{"padding",        required_argument, 0, 'p'},
 		{"size",           required_argument, 0, 's'},
 		{"mode",           required_argument, 0, 'M'},
+        {"format",         required_argument, 0, 'f'},
 		{0, 0, 0, 0}
 	};
 
@@ -57,6 +58,7 @@ int main(int argc, char *argv[])
 			case 'm': params.metadata = optarg;    break;
 			case 'M': params.mode = optarg;        break;
 			case 'S': params.max_size = true;      break;
+            case 'f': params.format = optarg;      break;
 
 			case 'i':
 				if (sscanf(optarg, "%d", &params.indentation) != 1)

--- a/src/packer.cpp
+++ b/src/packer.cpp
@@ -764,21 +764,35 @@ struct Packer
 	{
 		writer.StartObject();
 
-		writer.String("width");
+		writer.String("meta");
+		writer.StartObject();
+        
+		writer.String("size");
+		writer.StartObject();
+        
+		writer.String("w");
 		writer.Int(result.width);
 
-		writer.String("height");
+		writer.String("h");
 		writer.Int(result.height);
 
-		writer.String("sprites");
-		writer.StartObject();
+        writer.EndObject();
+        writer.EndObject();
+            
+		writer.String("frames");
+		writer.StartArray();
 
 		for (size_t i = 0; i < result.sprites.size(); i++)
 		{
 			const Sprite &sprite = result.sprites[i];
 
-			writer.String(sprite.filename);
-			writer.StartObject();
+            writer.StartObject();
+            
+            writer.String("filename");
+			writer.Key(sprite.filename);
+			
+            writer.String("frame");
+            writer.StartObject();
 
 			writer.String("x");
 			writer.Int(sprite.x);
@@ -788,20 +802,22 @@ struct Packer
 
 			if (sprite.rotated)
 			{
-				writer.String("width");
+				writer.String("w");
 				writer.Int(sprite.height);
 
-				writer.String("height");
+				writer.String("h");
 				writer.Int(sprite.width);
 			}
 			else
 			{
-				writer.String("width");
+				writer.String("w");
 				writer.Int(sprite.width);
 
-				writer.String("height");
+				writer.String("h");
 				writer.Int(sprite.height);
 			}
+            
+            writer.EndObject();
 
 			if (params.rotate)
 			{
@@ -834,11 +850,11 @@ struct Packer
 					it->value.Accept(writer);
 				}
 			}
-
+            
 			writer.EndObject();
 		}
 
-		writer.EndObject();
+        writer.EndArray();
 		writer.EndObject();
 	}
 };

--- a/src/packer.cpp
+++ b/src/packer.cpp
@@ -758,7 +758,7 @@ struct Packer
 
 		fclose(file);
 	}
-
+    
 	template<typename T>
 	void write_json(const Result &result, T &writer)
 	{
@@ -788,8 +788,12 @@ struct Packer
 
             writer.StartObject();
             
+            // Removes the extension from the "filename" parameter
+            std::string working_name = sprite.filename;
+            std::size_t last_index = working_name.find_last_of(".");
+            std::string name = working_name.substr(0, last_index);
             writer.String("filename");
-			writer.Key(sprite.filename);
+            writer.Key(name.c_str());
 			
             writer.String("frame");
             writer.StartObject();

--- a/src/packer.cpp
+++ b/src/packer.cpp
@@ -860,6 +860,9 @@ struct Packer
     void fill_meta_info(const Result &result, T &writer, const char *filename) {
         writer.String("meta");
         writer.StartObject();
+        
+        writer.String("app");
+        writer.Key("https://github.com/urraka/texpack");
 
         // Removes the extension and path, then adds .png back to the file namehub
         std::string working_name = remove_extension(filename);

--- a/src/packer.h
+++ b/src/packer.h
@@ -9,7 +9,7 @@ namespace pkr
 			output(0),
 			metadata(0),
 			mode("auto"),
-			format("jsonhash"),
+			format("legacy"),
 			bleed(false),
 			premultiplied(false),
 			pot(false),

--- a/src/packer.h
+++ b/src/packer.h
@@ -9,6 +9,7 @@ namespace pkr
 			output(0),
 			metadata(0),
 			mode("auto"),
+			format("jsonhash"),
 			bleed(false),
 			premultiplied(false),
 			pot(false),
@@ -25,6 +26,7 @@ namespace pkr
 		const char *output;
 		const char *metadata;
 		const char *mode;
+		const char *format;
 		bool bleed;
 		bool premultiplied;
 		bool pot;


### PR DESCRIPTION
The program now supports output for JSON Hash and JSON Array formats. This can be specified by the user by using the `--format` tag and using the parameters `legacy`, `jsonarray`, or `jsonhash`. 

There is already an incredible backend for this program, and creating more formats will make this a desirable command line alternative to TexturePacker, just like the photoshop bi-product Layer2SpriteSheet.