### PR TITLE
Windows build support in 2026

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,16 @@
-cmake_minimum_required(VERSION 3.0)
-project(texpack)
+cmake_minimum_required(VERSION 3.15)
 
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
+project(texpack LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(MSVC)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif()
 
 find_package(PNG REQUIRED)
-include_directories(${PNG_INCLUDE_DIRS})
-
 find_package(ZLIB REQUIRED)
-include_directories(${ZLIB_INCLUDE_DIRS})
 
 set(SOURCES
     src/main.cpp
@@ -24,4 +26,8 @@ set(SOURCES
 )
 
 add_executable(texpack ${SOURCES})
-target_link_libraries(texpack  PNG::PNG ZLIB::ZLIB)
+
+target_link_libraries(texpack PRIVATE
+    PNG::PNG
+    ZLIB::ZLIB
+)

--- a/README.md
+++ b/README.md
@@ -280,24 +280,32 @@ make
 git clone https://github.com/Microsoft/vcpkg.git
 cd vcpkg
 bootstrap-vcpkg.bat
-vcpkg integrate install 
+vcpkg integrate install
+# Note the response output like
+# CMake projects should use: "-DCMAKE_TOOLCHAIN_FILE=<your_local_path>/vcpkg/scripts/buildsystems/vcpkg.cmake"
+# you will need it later
 
 # install dependencies
 vcpkg install libpng --triplet x64-windows
-vcpkg install zlib --triplet x64-windows
+# zlib is a dependency of libpng so it's installed automatically
+# vcpkg install zlib --triplet x64-windows
 # or for static linking
 vcpkg install libpng:x64-windows-static
-vcpkg install zlib:x64-windows-static
+# zlib is a dependency of libpng so it's installed automatically
+# vcpkg install zlib:x64-windows-static
 
 # generate project and compile
-git clone https://github.com/kerskuchen/texpack.git
+git clone https://github.com/urraka/texpack.git
 cd texpack
 mkdir solution
 cd solution
-cmake .. -G "Visual Studio 16 2019" -DCMAKE_TOOLCHAIN_FILE="D:/UserLib/vcpkg/scripts/buildsystems/vcpkg.cmake"
+cmake .. -G "Visual Studio 18 2026" -A x64 -DCMAKE_TOOLCHAIN_FILE=<your_local_path>/vcpkg/scripts/buildsystems/vcpkg.cmake
 # or for static linking
-cmake .. -G "Visual Studio 16 2019" -DCMAKE_TOOLCHAIN_FILE="D:/UserLib/vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows-static
+cmake .. -G "Visual Studio 18 2026" -A x64 -DCMAKE_TOOLCHAIN_FILE=<your_local_path>/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows-static
 
 # Then we can open the solution and build it or run the following in a developer console:
-msbuild texpack.vcxproj /nologo /p:configuration=Release /p:platform=x64 /p:OutDir=..\bin\
+msbuild texpack.slnx /nologo /p:configuration=Release
+# the binary will be in Release directory
 ```
+
+For information about **developer console** [see here](https://learn.microsoft.com/en-us/visualstudio/ide/reference/command-prompt-powershell?view=visualstudio).

--- a/src/getopt.h
+++ b/src/getopt.h
@@ -56,7 +56,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma warning(disable : 4996);
+#pragma warning(disable : 4996)
 
 #define __GETOPT_H__
 


### PR DESCRIPTION
A few changes that target building binary using CMake on Windows:
1. CMakeLists version updated so it can be used with current CMake.
2. Readme updated with more details to help in the process.
3. One small fix that led to warning during build (unnecessary `;` in pragma line).